### PR TITLE
Sub resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ As the provided ARM template generates many resources in addition to Contrast sp
 - [Parameter Reference to Vault Keys](/WebSite.parameters.json#L8:L39)
 - [Declaration of Template Variables](/WebSite.json#L85:L90)
 - [Setup of Contrast Environment Variables](/WebSite.json#L125:L153)
-- [Addition of Contrast Extension](/WebSite.json#L224:L232)
+- [Addition of Contrast Extension](/WebSite.json#L158:L166)
 
 ## Setup
 1. Define 4 secrets in Azure Key Vault: `contrastApiKey`, `contrastAgentServiceKey`, `contrastAgentUsername` and `contrastURL` -- values for these can be found by logging in to Contrast and navigating to Organization Settings -> API

--- a/WebSite.json
+++ b/WebSite.json
@@ -83,8 +83,8 @@
   "variables": {
     "webSiteName": "[concat('webSite', uniqueString(resourceGroup().id))]",
     "contrastExtensionPackage": {
-      "Dotnet": "Contrast.Net.Azure.SiteExtension",
-      ".NET Framework": "Contrast.Net.Azure.SiteExtension",
+      "Dotnet": "Contrast.NET.Azure.SiteExtension",
+      ".NET Framework": "Contrast.NET.Azure.SiteExtension",
       "DotnetCore":  "Contrast.NetCore.Azure.SiteExtension",
       ".NET Core": "Contrast.NetCore.Azure.SiteExtension"
     }

--- a/WebSite.json
+++ b/WebSite.json
@@ -153,7 +153,18 @@
             }
           ]
         }
-      }
+      },
+      "resources": [
+        {
+          "type": "Microsoft.Web/sites/siteextensions",
+          "name": "[concat(variables('webSiteName'), '/', variables('contrastExtensionPackage')[parameters('contrastDotNetOrDotnetCore')])]",
+          "dependsOn": [
+            "[resourceId('Microsoft.Web/sites/', variables('webSiteName'))]"
+          ],
+          "apiVersion": "2018-11-01",
+          "location": "[resourceGroup().location]"
+        }
+      ]
     },
     {
       "apiVersion": "2014-04-01",
@@ -220,15 +231,6 @@
         "name": "[concat(parameters('hostingPlanName'), '-', resourceGroup().name)]",
         "targetResourceUri": "[concat(resourceGroup().id, '/providers/Microsoft.Web/serverfarms/', parameters('hostingPlanName'))]"
       }
-    },
-    {
-      "type": "Microsoft.Web/sites/siteextensions",
-      "name": "[concat(variables('webSiteName'), '/', variables('contrastExtensionPackage')[parameters('contrastDotNetOrDotnetCore')])]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/', variables('webSiteName'))]"
-      ],
-      "apiVersion": "2018-11-01",
-      "location": "[resourceGroup().location]"
     }
   ]
 }


### PR DESCRIPTION
Move extension application to a sub-resource of the app service instance, improving reliability; previous approach should have waited until app service deploy is complete, but it seemed to have a race condition, possibly related to the configuration causing a restart.